### PR TITLE
Refactor VIF class object model

### DIFF
--- a/os_vif/__init__.py
+++ b/os_vif/__init__.py
@@ -56,7 +56,7 @@ def plug(vif, instance):
     Given a model of a VIF, perform operations to plug the VIF properly.
 
     :param vif: `os_vif.objects.VIF` object.
-    :param instance: `nova.objects.Instance` object.
+    :param instance: `os_vif.objects.InstanceInfo` object.
     :raises `exception.LibraryNotInitialized` if the user of the library
             did not call os_vif.initialize(**config) before trying to
             plug a VIF.
@@ -68,11 +68,11 @@ def plug(vif, instance):
     if _EXT_MANAGER is None:
         raise os_vif.exception.LibraryNotInitialized()
 
-    vif_type = vif.type
+    vif_plugin = vif.plugin
     try:
-        plugin = _EXT_MANAGER[vif_type]
+        plugin = _EXT_MANAGER[vif_plugin]
     except KeyError:
-        raise os_vif.exception.NoMatchingPlugin(vif_type=vif_type)
+        raise os_vif.exception.NoMatchingPlugin(vif_plugin=vif_plugin)
 
     try:
         LOG.debug("Plugging vif %s", vif)
@@ -99,11 +99,11 @@ def unplug(vif):
     if _EXT_MANAGER is None:
         raise os_vif.exception.LibraryNotInitialized()
 
-    vif_type = vif.type
+    vif_plugin = vif.plugin
     try:
-        plugin = _EXT_MANAGER[vif_type]
+        plugin = _EXT_MANAGER[vif_plugin]
     except KeyError:
-        raise os_vif.exception.NoMatchingPlugin(vif_type=vif_type)
+        raise os_vif.exception.NoMatchingPlugin(vif_plugin=vif_plugin)
 
     try:
         LOG.debug("Unplugging vif %s", vif)

--- a/os_vif/base.py
+++ b/os_vif/base.py
@@ -19,18 +19,6 @@ import six
 class PluginBase(object):
     """Base class for all VIF plugins."""
 
-    VIF_TYPE = 'unknown'
-    """
-    Should be overridden with a string representing the VIF type the plugin
-    supports.
-    """
-
-    SUPPORTED_VNIC_TYPES = (None, )
-    """
-    Should be overridden with one or more constants for VNIC types in
-    `os_vif.vnic_types`.
-    """
-
     def __init__(self, **config):
         """
         Sets up the plugin using supplied kwargs representing configuration
@@ -43,7 +31,7 @@ class PluginBase(object):
         """
         Given a model of a VIF, perform operations to plug the VIF properly.
 
-        :param instance: `nova.objects.Instance` object.
+        :param instance: `os_vif.objects.InstanceInfo` object.
         :param vif: `os_vif.objects.VIF` object.
         :raises `processutils.ProcessExecutionError`. Plugins implementing
                 this method should let `processutils.ProcessExecutionError`

--- a/os_vif/exception.py
+++ b/os_vif/exception.py
@@ -48,7 +48,7 @@ class LibraryNotInitialized(ExceptionBase):
 
 
 class NoMatchingPlugin(ExceptionBase):
-    msg_fmt = _("No plugin was found that handles VIF of type %(vif_type)s")
+    msg_fmt = _("No VIF plugin was found with name %(vif_plugin)s")
 
 
 class PlugException(ExceptionBase):

--- a/os_vif/objects/vif.py
+++ b/os_vif/objects/vif.py
@@ -13,31 +13,6 @@
 from oslo_versionedobjects import base
 from oslo_versionedobjects import fields
 
-from os_vif import vnic_types
-
-# Constants for dictionary keys in the 'vif_details' field in the VIF
-# class
-VIF_DETAILS_OVS_HYBRID_PLUG = 'ovs_hybrid_plug'
-VIF_DETAILS_PHYSICAL_NETWORK = 'physical_network'
-
-# The following two constants define the SR-IOV related fields in the
-# 'vif_details'. 'profileid' should be used for VIF_TYPE_802_QBH,
-# 'vlan' for VIF_TYPE_HW_VEB
-VIF_DETAILS_PROFILEID = 'profileid'
-VIF_DETAILS_VLAN = 'vlan'
-
-# Constants for vhost-user related fields in 'vif_details'.
-# vhost-user socket path
-VIF_DETAILS_VHOSTUSER_SOCKET = 'vhostuser_socket'
-# Specifies whether vhost-user socket should be plugged
-# into ovs bridge. Valid values are True and False
-VIF_DETAILS_VHOSTUSER_OVS_PLUG = 'vhostuser_ovs_plug'
-
-# Constant for max length of network interface names
-# eg 'bridge' in the Network class or 'devname' in
-# the VIF class
-_NIC_NAME_LEN = 14
-
 
 class VIF(base.VersionedObject):
     """Represents a virtual network interface."""
@@ -45,96 +20,162 @@ class VIF(base.VersionedObject):
     VERSION = '1.0'
 
     fields = {
+        # Unique identifier of the VIF port
         'id': fields.UUIDField(),
-        'ovs_interfaceid': fields.StringField(),
-        # MAC address
-        'address': fields.StringField(nullable=True),
+
+        # The network to which the VIF is connected
         'network': fields.ObjectField('Network', nullable=True),
-        'type': fields.StringField(),
-        'details': fields.DictOfStringsField(nullable=True),
-        'profile': fields.DictOfStringsField(nullable=True),
-        'devname': fields.StringField(nullable=True),
-        'vnic_type': fields.StringField(),
-        'active': fields.BooleanField(),
-        'preserve_on_delete': fields.BooleanField(),
+
+        # MAC address
+        # TODO(berrange) how about a MACAddressField() type
+        'address': fields.StringField(nullable=True),
+
+        # Whether the VIF is initially up. If False, we must
+        # wait for an event notification of online status
+        'active': fields.BooleanField(default=True),
+
+        # Whether the VIF was created by an external entity,
+        # so Nova should avoid deleting VIF on instance
+        # deletion
+        'preserve_on_delete': fields.BooleanField(default=False),
+
+        # Name of the plugin to use for performing host OS
+        # setup / teardown actions
+        'plugin': fields.StringField()
     }
 
-    def __init__(self, id=None, address=None, network=None, type=None,
-                 details=None, devname=None, ovs_interfaceid=None,
-                 qbh_params=None, qbg_params=None, active=False,
-                 vnic_type=vnic_types.NORMAL, profile=None,
-                 preserve_on_delete=False):
-        details = details or {}
-        ovs_id = ovs_interfaceid or id
-        if not devname:
-            devname = ("nic" + id)[:_NIC_NAME_LEN]
-        super(VIF, self).__init__(id=id, address=address, network=network,
-                                  type=type, details=details,
-                                  devname=devname,
-                                  ovs_interfaceid=ovs_id,
-                                  qbg_params=qbg_params, qbh_params=qbh_params,
-                                  active=active, vnic_type=vnic_type,
-                                  profile=profile,
-                                  preserve_on_delete=preserve_on_delete,
-                                  )
 
-    def devname_with_prefix(self, prefix):
-        """Returns the device name for the VIF, with the a replaced prefix."""
-        return prefix + self.devname[3:]
+class VIFTap(VIF):
+    # Maps to libvirt type="ethernet" which just implies a
+    # bare TAP device, all setup delegated to plugin
 
-    # TODO(jaypipes): It's silly that there is a br_name and a (different)
-    # bridge_name attribute, but this comes from the original libvirt/vif.py.
-    # Clean this up and use better names for the attributes.
-    @property
-    def bridge_name(self):
-        return self.network.bridge
+    fields = {
+        # Name of the TAP device to create
+        'devname': fields.StringField()
+    }
 
-    @property
-    def br_name(self):
-        return ("qbr" + self.id)[:_NIC_NAME_LEN]
 
-    @property
-    def veth_pair_names(self):
-        return (("qvb%s" % self.id)[:_NIC_NAME_LEN],
-                ("qvo%s" % self.id)[:_NIC_NAME_LEN])
+class VIFBridge(VIFTap):
+    # Maps to libvirt type='bridge'
 
-    @property
-    def ovs_hybrid_plug(self):
-        return self.details.get(VIF_DETAILS_OVS_HYBRID_PLUG, False)
+    fields = {
+        # Name of the bridge device to connect to
+        'brname': fields.StringField(),
 
-    @property
-    def physical_network(self):
-        phy_network = self.network['meta'].get('physical_network')
-        if not phy_network:
-            phy_network = self.details.get(VIF_DETAILS_PHYSICAL_NETWORK)
-        return phy_network
+        # Whether the bridge device should be automatically
+        # created if not already present
+        'autocreate': fields.BooleanField(),
+    }
 
-    @property
-    def profileid(self):
-        return self.details.get(VIF_DETAILS_PROFILEID)
 
-    @property
-    def vlan(self):
-        return self.details.get(VIF_DETAILS_VLAN)
+class VIFOpenVSwitch(VIFBridge):
+    # Maps to libvirt type='bridge' with openvswitch port profile
 
-    @property
-    def vhostuser_mode(self):
-        return self.details.get(VIF_DETAILS_VHOSTUSER_MODE)
+    fields = {
+        'profileID': fields.StringField(),
 
-    @property
-    def vhostuser_socket(self):
-        return self.details.get(VIF_DETAILS_VHOSTUSER_SOCKET)
+        'interfaceID': fields.UUIDField(nullable=True)
+    }
 
-    @property
-    def vhostuser_ovs_plug(self):
-        return self.details.get(VIF_DETAILS_VHOSTUSER_OVS_PLUG)
 
-    @property
-    def fixed_ips(self):
-        return [fixed_ip for subnet in self.network['subnets']
-                         for fixed_ip in subnet['ips']]
+class VIFMidonet(VIFBridge):
+    # Maps to libvirt type='bridge' with midonet port profile
 
-    @property
-    def floating_ips(self):
-        return [floating_ip for fixed_ip in self.fixed_ips
-                            for floating_ip in fixed_ip['floating_ips']]
+    fields = {
+        'interfaceID': fields.UUIDField(nullable=True)
+    }
+
+
+class VIFHostDevice(VIF):
+    # Abstract base
+
+    fields = {
+        # The PCI address of the device to assign
+        # TODO(berrange): should be a fields.PCIAddressField()
+        'address': fields.StringField()
+
+        # The VLAN number to configure
+        'vlan': fields.IntegerField()
+    }
+
+
+class VIFHostDeviceDirect(VIFHostDevice):
+    # Maps to libvirt type='direct' with mode='passthrough'
+    pass
+
+
+class VIFHostDeviceAssigned(VIFHostDevice):
+    # Maps to libvirt hostdev (ie PCI device assignment)
+    pass
+
+
+class VIFDirect(VIF):
+    # Abstract base
+
+    fields = {
+        # Name of the ethernet device to associate with
+        'devname': fields.StringField()
+    }
+
+
+class VIFDirect801QBG(VIFDirect):
+    fields = {
+        'managerID': fields.IntegerField(nullable=True),
+
+        'typeID': fields.IntegerField(nullable=True),
+
+        'typeIDVersion': fields.IntegerField(nullable=True),
+
+        'instanceID': fields.UUIDField(nullable=True),
+    }
+
+
+class VIFDirect801QBH(VIFDirect):
+
+    fields = {
+        'profileID': fields.StringField(),
+    }
+
+
+class VIFVHostUser(VIF):
+
+    fields = {
+        # Path to the UNIX domain socket
+        'path': fields.StringField()
+
+        # Sharing mode for the socket
+        'mode': fields.StringField()
+    }
+
+
+class VIFDVS(VIF):
+    # Maps to VMWare DVS network...
+    # unless one of the other types alreadyu has the right
+    # info for vmware, and we could just use that with a
+    # different plugin class provided. Unclear
+
+    fields = {
+        # TODO(berrange) figure out if any are needed
+    }
+
+
+class InstanceInfo(base.VersionedObject):
+
+    """Metadata about the instance that is allowed to be used
+       by the VIF plugin"""
+
+    VERSION = "1.0"
+
+    fields = {
+        # Name of the instance
+        'name': fields.StringField()
+
+        # UUID of the instance
+        'uuid': fields.UUIDField()
+
+        # Human friendly name of the instance
+        'display_name': fields.StringField()
+
+        # Project id
+        'projectid': fields.StringField()
+    }


### PR DESCRIPTION
Currently the VIF class has a 'type' field that determines what
values are expected in the 'details' dictionary, which which
plugin is used to integration host actions.

There are ultimately many neutron mechanisms which map to the
same underlying libvirt VIF configuration, but have different
host integration work. For this reason, it is desirable to
disassociate the VIF configuration from the plugin actions.

This removes the 'type' field from the VIF class (along with
many other fields), and introduces subclasses to represent
the various different guest facing configuration approaches
for VIF. The goal is that the VIF subclass have enough info
to allow the guest XML (or non-libvirt equiv) to be created.

There is now an explicit 'plugin' field which provides
the name of the plugin class to use for host OS integration.

Thus, instead of there being a 1:1 mapping between Neutron
mechanisms and VIF types and plugin classes, there is now
an M:N mapping. ie, multiple different Neutron mechanisms
can all use the same VIF subclass to represent their config,
but provide different plugin classes to do their host OS
setup. This is key to avoiding the explosion in number of
VIF types.

NB, this has not updated any of the plugin impls, not
detailed how the existing "legacy" VIF types will be dealt
with. This set of VIF subclasses defines an idealized
minimal set of VIF types. When talking to old neutron
Nova will have to some how re-write the old VIF types to
use the new VIF subclasses as needed, and provide some
suitable plugin impls for them. For modern VIF types
the vendor will be responsible for providing the plugin
impls. This suggests, that the _plugins dir probably in
fact belongs in Nova.
