### PR TITLE
Add os_vif.objects.InstanceInfo model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,8 @@ A library for plugging and unplugging virtual interfaces in OpenStack.
 Features
 --------
 
-* A base VIF plugin class that supplies a plug() and unplug() interface.
-* A set of plugins that implement plug() and unplug() for a variety
-  of common virtual interface types.
+* A base VIF plugin class that supplies a plug() and unplug() interface
+* Versioned objects that represent a virtual interface and its components
 
 Usage
 -----
@@ -30,11 +29,8 @@ keyword arguments for configuration options::
                       forward_bridge_interface=['all'])
 
 Once the `os_vif` library is initialized, there are only two other library
-functions: `os_vif.plug()` and `os_vif.unplug()`. The `os_vif.plug()` function
-accepts two arguments. The first argument should be a `os_vif.objects.VIF`
-object. The second should be a `nova.objects.Instance` object representing
-the virtual machine that should have a virtual interface plugged into the
-underlying network::
+functions: `os_vif.plug()` and `os_vif.unplug()`. Both methods accept a single
+argument of type `os_vif.objects.VIF`::
 
     import uuid
 
@@ -45,6 +41,7 @@ underlying network::
 
     instance_uuid = 'd7a730ca-3c28-49c3-8f26-4662b909fe8a'
     instance = nova_objects.Instance.get_by_uuid(instance_uuid)
+    instance_info = vif_objects.InstanceInfo.from_nova_instance(instance)
 
     subnet = vif_objects.Subnet(cidr='192.168.1.0/24')
     subnets = vif_objects.SubnetList([subnet])
@@ -67,18 +64,19 @@ underlying network::
                           profile=None,
                           vnic_type=vnic_types.NORMAL,
                           active=True,
-                          preserve_on_delete=False)
+                          preserve_on_delete=False,
+                          instance_info=instance_info)
 
     # Now do the actual plug operations to connect the VIF to
     # the backing network interface.
     try:
-        os_vif.plug(vif, instance)
+        os_vif.plug(vif)
     except vif_exc.PlugException as err:
         # Handle the failure...
 
     # If you are removing a virtual machine and its interfaces,
     # you would use the unplug() operation:
     try:
-        os_vif.unplug(vif, instance)
+        os_vif.unplug(vif)
     except vif_exc.UnplugException as err:
         # Handle the failure...

--- a/os_vif/objects/__init__.py
+++ b/os_vif/objects/__init__.py
@@ -12,6 +12,7 @@
 
 
 def register_all():
+    __import__('os_vif.objects.instance_info')
     __import__('os_vif.objects.network')
     __import__('os_vif.objects.subnet')
     __import__('os_vif.objects.vif')

--- a/os_vif/objects/instance_info.py
+++ b/os_vif/objects/instance_info.py
@@ -1,0 +1,36 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_versionedobjects import base
+from oslo_versionedobjects import fields
+
+
+class InstanceInfo(base.VersionedObject):
+    """Represents important information about a Nova instance."""
+    # Version 1.0: Initial version
+    VERSION = '1.0'
+
+    fields = {
+        # UUID of the instance
+        'uuid': fields.UUIDField(),
+        # The instance name, directly from the Nova instance field of the
+        # same name
+        'name': fields.StringField(),
+        # The project/tenant ID that owns the instance
+        'project_id': fields.StringField(),
+    }
+
+    @classmethod
+    def from_nova_instance(cls, instance):
+        return cls(uuid=instance.uuid,
+                   name=instance.name,
+                   project_id=instance.project_id)

--- a/os_vif/objects/vif.py
+++ b/os_vif/objects/vif.py
@@ -46,6 +46,7 @@ class VIF(base.VersionedObject):
 
     fields = {
         'id': fields.UUIDField(),
+        'instance_info': fields.ObjectField('InstanceInfo'),
         'ovs_interfaceid': fields.StringField(),
         # MAC address
         'address': fields.StringField(nullable=True),
@@ -63,7 +64,7 @@ class VIF(base.VersionedObject):
                  details=None, devname=None, ovs_interfaceid=None,
                  qbh_params=None, qbg_params=None, active=False,
                  vnic_type=vnic_types.NORMAL, profile=None,
-                 preserve_on_delete=False):
+                 preserve_on_delete=False, instance_info=None):
         details = details or {}
         ovs_id = ovs_interfaceid or id
         if not devname:
@@ -76,6 +77,7 @@ class VIF(base.VersionedObject):
                                   active=active, vnic_type=vnic_type,
                                   profile=profile,
                                   preserve_on_delete=preserve_on_delete,
+                                  instance_info=instance_info,
                                   )
 
     def devname_with_prefix(self, prefix):


### PR DESCRIPTION
One thing that occurred to me when going to add the InstanceConfig
object from Dan's original pull request [1] was that it would be easier
to have only a single argument to the library's plug() and unplug()
method -- the os_vif.objects.VIF object only. The reason is because the
plugin describe() interface now returns a PluginInfo object that
describes the name of the plugin and the min and max object version that
the plugin understands. This object version is the VIF object version,
however the original design had a nova.objects.Instance object being
passed into the plug() and unplug() method. There was nothing in the
plugin describe() contract that indicated what version of the
nova.objects.Instance object the plugin understood, so I thought it
would be best to make a slimmed-down InstanceInfo object be an
ObjectField on the main VIF object and in that manner ensure that the
VIF object version could be the only version information that the
PluginInfo object would need to maintain.

[1]
https://github.com/berrange/os_vif/commit/18585c42b256159c85eeb1f8481a834385892298
