### PR TITLE
unit-tests: Coverage plus remove a non-test method that was copied

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,3 @@
 branch = True
 source = os_vif
 omit = os_vif/tests/*,os_vif/openstack/*
-
-[report]
-ignore-errors = True

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+covhtml
 *.py[cod]
 
 # C extensions

--- a/os_vif/tests/test_os_vif.py
+++ b/os_vif/tests/test_os_vif.py
@@ -24,9 +24,6 @@ class TestOSVIF(base.TestCase):
         super(TestOSVIF, self).setUp()
         os_vif._EXT_MANAGER = None
 
-    def test_something(self):
-        pass
-
     @mock.patch('stevedore.extension.ExtensionManager')
     def test_initialize(self, mock_EM):
         self.assertEqual(None, os_vif._EXT_MANAGER)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = os-vif
+name = os_vif
 summary = A library for plugging and unplugging virtual interfaces in OpenStack.
 description-file = README.rst
 author = OpenStack

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,pep8
+envlist = py27,py34,pep8
 skipsdist = True
 
 [testenv]
@@ -23,7 +23,11 @@ commands = flake8
 commands = {posargs}
 
 [testenv:cover]
-commands = python setup.py testr --coverage --testr-args='{posargs}'
+commands =
+  coverage erase
+  python setup.py testr --coverage --testr-args='--concurrency=1 {posargs}'
+  coverage combine
+  coverage html --include='os_vif/*' -d covhtml -i
 
 [testenv:docs]
 commands = python setup.py build_sphinx
@@ -52,7 +56,6 @@ commands = python setup.py build_sphinx
 #
 # Due to the upgrade to hacking 0.9.2 the following checking are
 # ignored on purpose for the moment and should be re-enabled.
-
 
 show-source = True
 ignore = E123,E125,E251,E265,H302,H402,H405,H803,H904,H404


### PR DESCRIPTION
Get the Python test coverage job working and remove a non-test method that had snuck in from Sahid's PR.
